### PR TITLE
Fixed a small mismatch with the parens

### DIFF
--- a/src/db/migrator/helper.clj
+++ b/src/db/migrator/helper.clj
@@ -109,7 +109,7 @@
         "add constraint"
         (or (helper/sqlize fk-name) (str from "_" to "_fk"))
         "foreign key"
-        (str "(" (or (helper/sqlize (str col "_id") to) ")"))
+        (str "(" (or (helper/sqlize (str col "_id")) to) ")")
         "references"
         to
         (str "(" (or (helper/sqlize pk) "id") ")")


### PR DESCRIPTION
I just started using the latest migrator, and I ran into an arguments bug. I think this was the intent, right?